### PR TITLE
fix(OIDC Implicit Core): IE not working with URLSearchParams

### DIFF
--- a/packages/oidc-implicit-core/package-lock.json
+++ b/packages/oidc-implicit-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawaii-framework/oidc-implicit-core",
-  "version": "1.0.9",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/oidc-implicit-core/package.json
+++ b/packages/oidc-implicit-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawaii-framework/oidc-implicit-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Core components for implementing Open ID Connect Implicit Flow",
   "author": "Ilionx",
   "email": "kriemens@ilionx.com",

--- a/packages/oidc-implicit-core/tsconfig.json
+++ b/packages/oidc-implicit-core/tsconfig.json
@@ -19,6 +19,7 @@
       "node_modules/@types"
     ],
     "lib": [
+      "es6",
       "es2015",
       "dom"
     ]

--- a/packages/oidc-implicit-core/tsconfig.json
+++ b/packages/oidc-implicit-core/tsconfig.json
@@ -19,7 +19,6 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es6",
       "es2015",
       "dom"
     ]

--- a/packages/oidc-implicit-core/utils/urlUtil.ts
+++ b/packages/oidc-implicit-core/utils/urlUtil.ts
@@ -1,5 +1,5 @@
 import { Token } from '../models/token.models';
-import { URLParams } from '../models/url-param.models';
+import { URLParams, AuthorizeParams } from '../models/url-param.models';
 
 export class UrlUtil {
   /**
@@ -42,25 +42,19 @@ export class UrlUtil {
    * @param {Object} urlVars
    * @returns {string}
    */
-  static createURLParameters(urlVars: Object): string {
-    const params = new URLSearchParams();
-
-    // Set the new Query string params.
-    for (const key in urlVars) {
-      if (urlVars.hasOwnProperty(key)) {
-
-        if (key === 'redirect_uri') {
-          urlVars[key] = UrlUtil.cleanHashFragment(urlVars[key]);
-        }
-
-        params.set(key, urlVars[key]);
-      }
+  static createURLParameters(urlVars: { redirect_uri?: string}): string {
+    if (urlVars.redirect_uri) {
+      urlVars.redirect_uri = UrlUtil.cleanHashFragment(urlVars.redirect_uri);
     }
-
-    return params.toString();
+    const params = [];
+    for (const urlVar of Object.keys(urlVars)) {
+      params.push(`${urlVar}=${urlVars[urlVar]}`);
+    }
+    return params.join('&');
   }
 
   /**
+   *
    * Get Hash Fragment parameters from sessionStorage
    * @param {string} hash_fragment
    * @returns {Token}


### PR DESCRIPTION
As they branch suggests, compatibility with IE11.

IE11 does not support UrlSearchParams